### PR TITLE
Update to Postsrsd 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,4 @@ RUN \
 COPY root/ /
 RUN chmod -v +x /etc/services.d/*/run /etc/cont-init.d/*
 
-EXPOSE 10001 10002
-
+EXPOSE 10003

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ postsrsd
 
 [Postfix Sender Rewriting Scheme daemon](https://github.com/roehling/postsrsd)
 
+PostSRSd 2.x+ requires at least Postfix 2.10 for socketmap support.
+
 ### Usage
 
  `docker run --rm --name postfix-postsrsd -e  SRS_DOMAIN=domaintouse.org -e "SRS_SECRET=k/bWL9OyMBGTJ9p4Hb1owcag" ajoergensen/postfix-postsrsd`
@@ -13,8 +15,7 @@ postsrsd
 - `SRS_SECRET`: Secret used to hash the sender email. Generate one with this command: `dd if=/dev/random bs=18 count=1 | base64` (mandatory)
 - `SRS_EXCLUDE_DOMAINS`: Senders in these domains will not be rewritten (optional)
 - `SRS_SEPARATOR`: Separator used when rewriting the sender email, default is "=" which generates a rewritten address like this: `SRS0+xxxx=yy=example.com=alice@yourdomain.org` (optional)
-- `SRS_FORWARD_PORT`: Port used for forward SRS, default is 10001 (optional)
-- `SRS_REVERSE_PORT`: Port used for reverse SRS, default is 10002 (optional)
+- `SRS_SOCKET_PORT`: Port used for socketmap SRS, default is 10003 (optional)
 - `SRS_HASHLENGTH`: Hash length used when rewriting the sender, default is 4 (optional)
 - `SRS_HASHMIN`: Minimum hash length to consider when doing reverse SRS, default is 4 and should match `SRS_HASHLENGTH` (optional)
 - `RUN_AS`: User to run the daemon as, default is postsrsd (optional)

--- a/root/etc/services.d/postsrsd/run
+++ b/root/etc/services.d/postsrsd/run
@@ -33,8 +33,11 @@ echo "hash-minimum = ${SRS_HASHMIN}" >> "${CONFIG_FILE}"
 echo "always-rewrite = off" >> "${CONFIG_FILE}"
 echo "unprivileged-user = ${RUN_AS}" >> "${CONFIG_FILE}"
 echo "chroot-dir = ${CHROOT}" >> "${CONFIG_FILE}"
-echo "syslog = on" >> "${CONFIG_FILE}"
+echo "syslog = off" >> "${CONFIG_FILE}"
 
 echo "${SRS_SECRET}" > "${SECRET_FILE}"
 
-/usr/sbin/postsrsd -C "${CONFIG_FILE}"
+# Turn off bash debug, and prepend datetime to every outputed line.
+set +x
+echo "$(date +'%Y-%m-%d %H:%M:%S') - Starting postsrsd"
+/usr/sbin/postsrsd -C "${CONFIG_FILE}" 2>&1 | while IFS= read -r line; do echo "$(date +'%Y-%m-%d %H:%M:%S') - $line"; done

--- a/root/etc/services.d/postsrsd/run
+++ b/root/etc/services.d/postsrsd/run
@@ -2,13 +2,15 @@
 
 set -x
 
+CONFIG_FILE="/etc/postsrsd.conf"
+SECRET_FILE="/etc/postsrsd.secret"
+
 : ${SRS_DOMAIN:=localhost.localnet}
 # Generate by running 'dd if=/dev/random bs=18 count=1 | base64'
 : ${SRS_SECRET:="setthistoaverylongstring"}
 : ${SRS_EXCLUDE_DOMAINS:=""}
 : ${SRS_SEPARATOR:="="}
-: ${SRS_FORWARD_PORT:=10001}
-: ${SRS_REVERSE_PORT:=10002}
+: ${SRS_SOCKET_PORT:=10003}
 : ${SRS_HASHLENGTH:=4}
 : ${SRS_HASHMIN:=4}
 : ${RUN_AS:=postsrsd}
@@ -18,6 +20,21 @@ set -x
 mkdir -p ${CHROOT}
 chown -R ${RUN_AS} ${CHROOT}
 
-echo "${SRS_SECRET}" > /etc/postsrsd.secret
+echo "domains = {${SRS_EXCLUDE_DOMAINS}}" > "${CONFIG_FILE}"
+echo "srs-domain = ${SRS_DOMAIN}" >> "${CONFIG_FILE}"
+echo "socketmap = inet:${SRS_LISTEN_ADDRESS}:${SRS_SOCKET_PORT}" >> "${CONFIG_FILE}"
+echo "keep-alive = 30" >> "${CONFIG_FILE}"
+echo "original-envelope = embedded" >> "${CONFIG_FILE}"
+echo "secrets-file = \"${SECRET_FILE}\"" >> "${CONFIG_FILE}"
+echo "separator = \"${SRS_SEPARATOR}\"" >> "${CONFIG_FILE}"
+echo "original-envelope = embedded" >> "${CONFIG_FILE}"
+echo "hash-length = ${SRS_HASHLENGTH}" >> "${CONFIG_FILE}"
+echo "hash-minimum = ${SRS_HASHMIN}" >> "${CONFIG_FILE}"
+echo "always-rewrite = off" >> "${CONFIG_FILE}"
+echo "unprivileged-user = ${RUN_AS}" >> "${CONFIG_FILE}"
+echo "chroot-dir = ${CHROOT}" >> "${CONFIG_FILE}"
+echo "syslog = on" >> "${CONFIG_FILE}"
 
-/usr/sbin/postsrsd -f "${SRS_FORWARD_PORT}" -r "${SRS_REVERSE_PORT}" -l ${SRS_LISTEN_ADDRESS} -d "${SRS_DOMAIN}" -s /etc/postsrsd.secret -a "${SRS_SEPARATOR}" -n "${SRS_HASHLENGTH}" -N "${SRS_HASHMIN}" -u "${RUN_AS}" -c "${CHROOT}" -X"${SRS_EXCLUDE_DOMAINS}"
+echo "${SRS_SECRET}" > "${SECRET_FILE}"
+
+/usr/sbin/postsrsd -C "${CONFIG_FILE}"


### PR DESCRIPTION
I use this container for my Mailcow Email Server to carry out the SRS function, recently this container got updated when I did a `docker compose pull`, which then broke my email delivery. I'm assuming you have a automatic pipeline to rebuild your containers every month or so, to keep them up to date and have not noticed this is currently broken.

The upstream package from alpine changed from Postsrsd 1.x to Postsrsd 2.x, which has broken this container. I have updated the `Dockerfile` and `run` file to bring it up to line with the postsrsd 2.x changes.

You will also need to update your postfix config from using tcp to socketmap for the canonical_maps. I changed the postsrsd port from 1001-1002 to 1003, to make it obvious it's a different protocol.

Below are the changes I also made to my postfix environment to get it working with the new version of postsrsd. Hopefully you will accept my merge request and we can get this container working again nicely.

####  data/conf/postfix/extra.cf
```
recipient_canonical_maps = tcp:172.22.1.42:10002, proxy:mysql:/opt/postfix/conf/sql/mysql_recipient_canonical_maps.cf
## changed to 
recipient_canonical_maps = socketmap:inet:172.22.1.42:10003:reverse, proxy:mysql:/opt/postfix/conf/sql/mysql_recipient_canonical_maps.cf
```


####  data/conf/postfix/master.cf
```
-o sender_canonical_maps=tcp:172.22.1.42:10001
## changed to
-o sender_canonical_maps=socketmap:inet:172.22.1.42:10003:forward
```
